### PR TITLE
99.9% of the way to duplicating boto2 functionality using boto3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ give your autoscaling group a lifecycle hook that publishes to an SNS topic that
 you configure in shudder. When shudder starts up, it will create an SQS queue
 for the instance it is running on and subscribe it to the SNS topic. It polls
 for new messages and waits for one that is a termination command for this
-instance, and sends a GET request to a configured endpoint telling it to
-shut down gracefully.
+instance. It can then send a GET request to a configured endpoint telling it to
+shut down gracefully, or execute commands.
 
 It can also detect when a spot instance has been scheduled for termination, 
 using the [instance termination notice](https://aws.amazon.com/blogs/aws/new-ec2-spot-instance-termination-notices/) 
@@ -32,6 +32,7 @@ sqs_prefix = "myapp"
 region = "us-east-1"
 sns_topic = "arn:aws:sns:us-east-1:723456455537:myapp-shutdowns"
 endpoint = "http://127.0.0.1:5000/youaregoingtodiesoon"
+commands = [["//etc/init.d/nginx", "stop"], ["/etc/init.d/filebeats", "stop"]]
 ```
 
 You can specify the config file path as an environment variable:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto==2.32.1
+boto3==1.4.4
 toml==0.8.2
 requests==2.4.3

--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
             if 'commands' in CONFIG:
                 for command in CONFIG["commands"]:
                     process = subprocess.Popen(command)
-                    while process.poll() is not None:
+                    while process.poll() is None:
                         time.sleep(30)
                         """Send a heart beat to aws"""
                         queue.record_lifecycle_action_heartbeat(message)

--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     sqs_connection, sqs_queue = queue.create_queue()
     sns_connection, subscription_arn = queue.subscribe_sns(sqs_queue)
     while True:
-        if queue.poll_queue(sns_connection, sqs_queue) \
+        if queue.poll_queue(sqs_connection, sqs_queue) \
                 or metadata.poll_instance_metadata():
             queue.clean_up_sns(sns_connection, subscription_arn, sqs_queue)
             requests.get(CONFIG["endpoint"])

--- a/shudder/__main__.py
+++ b/shudder/__main__.py
@@ -19,15 +19,25 @@ from shudder.config import CONFIG
 
 import time
 import requests
-
+import subprocess
 
 if __name__ == '__main__':
     sqs_connection, sqs_queue = queue.create_queue()
     sns_connection, subscription_arn = queue.subscribe_sns(sqs_queue)
     while True:
-        if queue.poll_queue(sqs_connection, sqs_queue) \
-                or metadata.poll_instance_metadata():
+        message = queue.poll_queue(sqs_connection, sqs_queue)
+        if message or metadata.poll_instance_metadata():
             queue.clean_up_sns(sns_connection, subscription_arn, sqs_queue)
-            requests.get(CONFIG["endpoint"])
+            if 'endpoint' in CONFIG:
+                requests.get(CONFIG["endpoint"])
+            if 'commands' in CONFIG:
+                for command in CONFIG["commands"]:
+                    process = subprocess.Popen(command)
+                    while process.poll() is not None:
+                        time.sleep(30)
+                        """Send a heart beat to aws"""
+                        queue.record_lifecycle_action_heartbeat(message)
+            """Send a complete lifecycle action"""
+            queue.complete_lifecycle_action(message)
             break
         time.sleep(5)

--- a/shudder/metadata.py
+++ b/shudder/metadata.py
@@ -22,3 +22,9 @@ def poll_instance_metadata():
     """Check instance metadata for a scheduled termination"""
     r = requests.get("http://169.254.169.254/latest/meta-data/spot/termination-time")
     return r.status_code < 400
+
+def get_instance_id():
+    """Check instance metadata for an instance id"""
+    r = requests.get("http://169.254.169.254/latest/meta-data/instance-id")
+    return r.text
+


### PR DESCRIPTION
The piece I'm missing is the policy creation on the SQS queue itself to allow SNS to send notifications in. This can easily be done via [sqs.client.add_permission](http://boto3.readthedocs.io/en/latest/reference/services/sqs.html#SQS.Client.add_permission), however we'll most likely be using a passed in role.  